### PR TITLE
Handle absolute paths in dotfiles and derive Typeable/Data

### DIFF
--- a/HaLeX_lib/Language/HaLex/FaAsDiGraph.hs
+++ b/HaLeX_lib/Language/HaLex/FaAsDiGraph.hs
@@ -77,7 +77,7 @@ tographviz' :: (Eq sy, Show sy, Ord st, Show st)
         -> Bool                  -- ^ Show sync states?
         -> [Char]
 tographviz' ndfa@(Ndfa v q s z delta) name shape orientation 
-           showState showLabel deadSt syncSt = "digraph " ++ name ++ " {\n " 
+           showState showLabel deadSt syncSt = "digraph \"" ++ name ++ "\" {\n " 
              ++ "rankdir = " ++ orientation ++ " ;\n " 
              ++ (showElemsListPerLine (showStates q)) ++ "\n " 
              ++ (showElemsListPerLine (showInitialStates s)) ++ "\n " 

--- a/HaLeX_lib/Language/HaLex/RegExp.hs
+++ b/HaLeX_lib/Language/HaLex/RegExp.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Language.HaLex.RegExp
@@ -32,6 +35,10 @@ module Language.HaLex.RegExp (
               , extREtoRE
               ) where
 
+import Data.Data (Data)
+import Data.Typeable (Typeable)
+
+
 -----------------------------------------------------------------------------
 -- * Data type with recursion pattern
 
@@ -45,7 +52,7 @@ data RegExp sy  = Empty                              -- ^ Empty Language
                 | OneOrMore (RegExp sy)              -- ^ One or more times (extended RegExp)
                 | Optional  (RegExp sy)              -- ^ Optional (extended RegExp)
                 | RESet     [sy]                     -- ^ Set (extended RegExp)
-   deriving (Read, Eq)
+   deriving (Read, Eq, Data, Typeable)
    
 -- | Catamorphism induced by the 'RegExp' inductive data type
 


### PR DESCRIPTION
Hi,

thanks for making this awesome library.

The first commit fixes the problem when the digraph name contains slashes.

The second is to be able to use SYB to traverse a regexp.

Sorry for merging the two PRs. If you don't want to merge one of them, I can split them up.

babush
